### PR TITLE
Fix generated pkg-config includedir and libdir

### DIFF
--- a/cray-xpmem.pc.in
+++ b/cray-xpmem.pc.in
@@ -1,11 +1,7 @@
-
+prefix=@prefix@
+exec_prefix=@exec_prefix@
 includedir=@includedir@
 libdir=@libdir@
-
-default_bindir=@default_bindir@
-default_fomdir=@default_fomdir@
-default_prefix=@default_prefix@
-default_shlibdir=@default_shlibdir@
 
 Cflags: -I${includedir}
 Description: XPMEM


### PR DESCRIPTION
`cray-xpmem.pc.in` doesn't define `prefix` and `exec_prefix` so the resulting pkg-config files don't work.

Fixes https://github.com/hjelmn/xpmem/issues/47.