### PR TITLE
Enable out-of-tree builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,5 +66,6 @@ AC_CONFIG_LINKS([kernel/xpmem_attach.c:kernel/xpmem_attach.c
                  kernel/xpmem_misc.c:kernel/xpmem_misc.c
                  kernel/xpmem_mmu_notifier.c:kernel/xpmem_mmu_notifier.c
                  kernel/xpmem_pfn.c:kernel/xpmem_pfn.c
-                 kernel/xpmem_private.h:kernel/xpmem_private.h])
+                 kernel/xpmem_private.h:kernel/xpmem_private.h
+                 test/run.sh:test/run.sh])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -59,4 +59,12 @@ AC_CONFIG_FILES([Makefile
                  kernel/xpmem
                  lib/Makefile
                  test/Makefile])
+AC_CONFIG_LINKS([kernel/xpmem_attach.c:kernel/xpmem_attach.c
+                 kernel/xpmem_get.c:kernel/xpmem_get.c
+                 kernel/xpmem_main.c:kernel/xpmem_main.c
+                 kernel/xpmem_make.c:kernel/xpmem_make.c
+                 kernel/xpmem_misc.c:kernel/xpmem_misc.c
+                 kernel/xpmem_mmu_notifier.c:kernel/xpmem_mmu_notifier.c
+                 kernel/xpmem_pfn.c:kernel/xpmem_pfn.c
+                 kernel/xpmem_private.h:kernel/xpmem_private.h])
 AC_OUTPUT

--- a/kernel/Makefile.am
+++ b/kernel/Makefile.am
@@ -24,9 +24,9 @@ KCPPFLAGS = -include @abs_top_builddir@/config.h -I@abs_top_srcdir@/include
 export KCPPFLAGS
 
 $(MODULE): ${module_sources}
-	$(MAKE) -C $(KERNEL_PATH) M=$(abs_builddir) src=$(abs_srcdir)
+	$(MAKE) -C $(KERNEL_PATH) M=$(abs_builddir)
 
 clean-local:
-	$(MAKE) -C $(KERNEL_PATH) M=$(abs_builddir) src=$(abs_srcdir) clean
+	$(MAKE) -C $(KERNEL_PATH) M=$(abs_builddir) clean
 
 .PHONY: $(MODULE)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,4 +1,5 @@
-AM_CPPFLAGS = -I@top_srcdir@/test/include \
+AM_CPPFLAGS = -I@srcdir@/include \
+              -I@builddir@/include \
               -I@top_srcdir@/include
 
 AM_LDFLAGS = @top_builddir@/lib/libxpmem.la


### PR DESCRIPTION
## What
This enables out-of-tree builds and tests.

## How?
Fix autoconf/automake files.

## Why?
We want to be able to build for multiple kernel versions, possibly from multiple containers using same source directory.

## Tested

On Centos 8.4 and 7.6.

In tree builds:
```
cd xpmem
./autogen.sh && ./configure --prefix=$(pwd)/install-devel
./autogen.sh && ./configure --prefix=$(pwd)/install-devel --with-kerneldir=/usr/src/kernels/3.10.0-957.el7.x86_64

make -j 8 && make install
insmod install-devel/lib/modules/3.10.0-957.el7.x86_64/kernel/xpmem/xpmem.ko
insmod install-devel/lib/modules/kernel/xpmem/xpmem.ko

make check
cd test && ./run.sh
```

Out of tree builds:
```
cd xpmem
./autogen.sh
mkdir ../build && cd ../build
../xpmem/configure --prefix=`pwd`/install-devel
../xpmem/configure --prefix=`pwd`/install-devel --with-kerneldir=/usr/src/kernels/3.10.0-957.el7.x86_64
.....
make check
cd test && ./run.sh
```