### PR TITLE
KERNEL: Add pre-fault of memory pages

### DIFF
--- a/m4/ac_path_kernel_source.m4
+++ b/m4/ac_path_kernel_source.m4
@@ -125,6 +125,16 @@ AC_DEFUN([AC_KERNEL_CHECKS],
 
   AC_CHECK_DECLS([vma_iter_init], [], [], [[#include <linux/mm_types.h>]])
 
+  AC_MSG_CHECKING(latest apply_to_page_range support)
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+      #include <linux/mm.h>
+      extern pte_fn_t callback;
+    ]], [[
+      int a = callback(NULL, 1, NULL);
+    ]])], [
+    AC_DEFINE([HAVE_LATEST_APPLY_TO_PAGE_RANGE], 1, [Have latest page iterator])
+  ], [])
+
   CPPFLAGS="$save_CPPFLAGS"
 ]
 )


### PR DESCRIPTION
## What
Add page pre-fault mechanism, forward, and backward.

## Why ?
Users of xpmem attachments are slown down because of individual page faults.

## How ?
PR can be looked at with individual commits.

Tweaking should not be needed but following is available:
- `echo 64 > /proc/xpmem/faults_after`
- `echo 32 > /proc/xpmem/faults_before`

We pre-fault pages forward and backward as `memcpy()` can sometimes be implemented as a `memmove()`. That later one can access memory pages with a combination of backward and forward pattern.

Tested on kernel 5.15 and 3.10 amd64, with test suite (missing vma, forward, reverse, multiple src vmas with holes...), mpirun (through ucx and ob1), tested latency with osu.