### PR TITLE
Compilation fix for ppc on Ubuntu18.04

### DIFF
--- a/kernel/xpmem_mmu_notifier.c
+++ b/kernel/xpmem_mmu_notifier.c
@@ -18,7 +18,7 @@
 #include <linux/percpu.h>
 
 #include <asm/tlbflush.h>
-#include <asm/uaccess.h>
+#include <linux/uaccess.h>
 
 #include "xpmem_internal.h"
 #include "xpmem_private.h"


### PR DESCRIPTION
Include linux/uaccess.h rather than asm/uaccess.h directly (#27).