### PR TITLE
GTEST: Handle case where root/sudo is always allowed

### DIFF
--- a/test/gtest/test_basic.cc
+++ b/test/gtest/test_basic.cc
@@ -161,7 +161,11 @@ TEST_F(test_basic, xpmem_get_not_allowed_permit) {
   for (auto pair : fails) {
     auto mem = create_xpmem(pair.first, pair.second);
     ASSERT_NE(-1, mem.first);
-    EXPECT_EQ(-1, mem.second);
+    if (geteuid() == 0) {
+      EXPECT_NE(-1, mem.second);
+    } else {
+      EXPECT_EQ(-1, mem.second);
+    }
     ASSERT_EQ(0, xpmem_remove(mem.first));
   }
 }


### PR DESCRIPTION
## What
The root/sudo user bypasses permissions with existing xpmem code, and test below is failing when ran with effective uid 0:
- `test_basic.xpmem_get_not_allowed_permit`

## Fix
Make the test reflect current code behavior. Tested:
- `user$ sudo ./test/gtest/gtest` and any owner on `/dev/xpmem`
- `# ./test/gtest/gtest` with any owner
- `user$ ./test/gtest/gtest` and `/dev/xpmem` with user owner