### PR TITLE
KERNEL: Support vma constified vm_flags on 6.3+ kernels

### DIFF
--- a/kernel/xpmem_attach.c
+++ b/kernel/xpmem_attach.c
@@ -582,12 +582,12 @@ xpmem_attach(struct file *file, xpmem_apid_t apid, off_t offset, size_t size,
 
 	xpmem_mmap_write_lock(current->mm);
 	vma = find_vma(current->mm, at_vaddr);
-	xpmem_mmap_write_unlock(current->mm);
 
 	vma->vm_private_data = att;
-	vma->vm_flags |=
-	    VM_DONTCOPY | VM_DONTDUMP | VM_IO | VM_DONTEXPAND | VM_PFNMAP;
+	vm_flags_set(vma,
+	    VM_DONTCOPY | VM_DONTDUMP | VM_IO | VM_DONTEXPAND | VM_PFNMAP);
 	vma->vm_ops = &xpmem_vm_ops;
+	xpmem_mmap_write_unlock(current->mm);
 
 	att->at_vma = vma;
 

--- a/kernel/xpmem_private.h
+++ b/kernel/xpmem_private.h
@@ -384,6 +384,13 @@ struct vma_iterator {
 	     (_vma) = (_vma)->vm_next)
 #endif
 
+#if (!HAVE_DECL_VM_FLAGS_SET)
+static inline void vm_flags_set(struct vm_area_struct *vma, vm_flags_t flags)
+{
+	vma->vm_flags |= flags;
+}
+#endif
+
 extern struct xpmem_thread_group *xpmem_tg_ref_by_segid(xpmem_segid_t);
 extern struct xpmem_thread_group *xpmem_tg_ref_by_apid(xpmem_apid_t);
 extern void xpmem_tg_deref(struct xpmem_thread_group *);

--- a/m4/ac_path_kernel_source.m4
+++ b/m4/ac_path_kernel_source.m4
@@ -135,6 +135,8 @@ AC_DEFUN([AC_KERNEL_CHECKS],
     AC_DEFINE([HAVE_LATEST_APPLY_TO_PAGE_RANGE], 1, [Have latest page iterator])
   ], [])
 
+  AC_CHECK_DECLS([vm_flags_set], [], [], [[#include <linux/mm.h>]])
+
   CPPFLAGS="$save_CPPFLAGS"
 ]
 )


### PR DESCRIPTION
## What
Support 6.3+ kernels where `vma->vm_flags` has become a const ("[mm: introduce vma->vm_flags wrapper functions]").


In our case, we own the vma anyways but it is already inserted, so using `vm_flags_set()` instead of `vm_flags_init()`. As that second API introduces lock checking, adapt the locking too.

## Tested
Build tested on 3.10 and 6.3.