### PR TITLE
CONFIGURE: Add '--enable-gtest' disabled by default

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -98,7 +98,7 @@ stages:
               set -eEx
               ./autogen.sh
               kernel_ver=$(dpkg -l | grep 'linux-headers-.*-generic' | awk '{print $2}')
-              ./configure --with-kerneldir=/usr/src/${kernel_ver}
+              ./configure --enable-gtest --with-kerneldir=/usr/src/${kernel_ver}
               make
             displayName: Build Ubuntu
             condition: contains(variables['build_container'], 'ubuntu')

--- a/ci/vm/entrypoint.sh
+++ b/ci/vm/entrypoint.sh
@@ -34,13 +34,13 @@ xpmem_build() {
   git checkout FETCH_HEAD
   ./autogen.sh
   if [[ $OS == *"ubuntu"* ]]; then
-    ./configure --with-kerneldir=/usr/src/linux-headers-"$(uname -r)"
+    ./configure --enable-gtest --with-kerneldir=/usr/src/linux-headers-"$(uname -r)"
     make -s
     make check
   elif [[ $OS == *"centos"* ]]; then
     # Build with GCC-8
     scl enable devtoolset-8 -- bash -c "
-      ./configure --with-kerneldir=/usr/src/kernels/'$(uname -r)'
+      ./configure --enable-gtest --with-kerneldir=/usr/src/kernels/'$(uname -r)'
       make -s
       make check
     "

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,6 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([int x = 0b101010;])],
 AC_MSG_RESULT([$have_cxx14])
 AC_LANG_POP
 CXXFLAGS="$save_CXXFLAGS"
-AM_CONDITIONAL([HAVE_CXX14], [test "x$have_cxx14" = "xyes"])
 
 # Checks for library functions.
 AC_PROG_GCC_TRADITIONAL
@@ -48,6 +47,21 @@ AC_ARG_WITH([module-prefix],
                             [Prefix for kernel module installation])],
             [],
             [with_module_prefix=$prefix])
+
+# Check for gtest being requested
+AC_ARG_ENABLE([gtest],
+  [AS_HELP_STRING([--enable-gtest],
+                  [Enable tests using the Google C++ Testing Framework.
+                  (Default is disabled.)])],
+  [enable_gtest=$enableval],
+  [enable_gtest=no])
+
+AC_MSG_CHECKING([for using Google C++ Testing Framework])
+AC_MSG_RESULT([$enable_gtest])
+# Check gtest can only build with C++14 support
+AS_IF([test "x$enable_gtest" = "xyes" && test "x$have_cxx14" != "xyes"],
+      [AC_MSG_ERROR([gtest enabled without C++14 compiler support])])
+AM_CONDITIONAL([HAVE_GTEST], [test "x$enable_gtest" = "xyes"])
 
 AC_SUBST([moduleprefix], [${with_module_prefix%%/}])
 AC_SUBST([initdir], [${sysconfdir}/init.d])

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -4,7 +4,7 @@
 # See file LICENSE for terms.
 #
 
-if HAVE_CXX14
+if HAVE_GTEST
 
 SUBDIRS = common/googletest
 


### PR DESCRIPTION
Disable gtest by default but make sure that CI explicitly enables it.

Tested `make && make install`:
- gcc <c++14: no gtest built with `--enable-gtest`/`--enable-gtest=yes`/`--enable-gtest=no`/nothing
- gcc supports c++14: gtest is only built with `--enable-gtest`/`--enable-gtest=yes`