### PR TITLE
Mainline kernel on VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ ltsugar.m4
 ltversion.m4
 lt~obsolete.m4
 install-sh
+.vagrant/
 
 # built targets
 cray-xpmem.pc

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -119,17 +119,17 @@ stages:
 
         strategy:
           matrix:
-            centos7:
-              BOX_NAME: centos7
+            ubuntu22-mainline:
+              BOX_NAME: ubuntu2204
+              KERNEL: mainline
+            ubuntu22:
+              BOX_NAME: ubuntu2204
             ubuntu18:
               BOX_NAME: ubuntu1804
             ubuntu20:
               BOX_NAME: ubuntu2004
-            ubuntu22:
-              BOX_NAME: ubuntu2204
-            ubuntu22-mainline:
-              BOX_NAME: ubuntu2204
-              KERNEL: mainline
+            centos7:
+              BOX_NAME: centos7
 
         steps:
           - checkout: self
@@ -164,8 +164,13 @@ stages:
               export VAGRANT_HOME=/opt/vagrant_home
               vagrant destroy -f
               vagrant global-status --prune
-              virsh destroy vm_${BOX_NAME} || true
-              virsh undefine vm_${BOX_NAME} || true
+              set +e
+              virsh destroy vm_${BOX_NAME}
+              virsh undefine vm_${BOX_NAME}
+              sudo rm -rf /var/lib/libvirt/images/*
+              virsh pool-destroy  default
+              virsh pool-delete   default
+              virsh pool-undefine default
             condition: always()
             displayName: Bring down VM
             workingDirectory: $(System.DefaultWorkingDirectory)/ci/vm/

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -57,7 +57,8 @@ stages:
             displayName: Check gtest code format
             workingDirectory: $(System.DefaultWorkingDirectory)/test/gtest
 
-  - stage: Build
+  - stage: Docker
+    displayName: Build on Docker
     dependsOn: Codestyle
     jobs:
       - job: Build
@@ -91,7 +92,7 @@ stages:
               kernel_ver=$(rpm -qa | grep kernel-devel | cut -d'-' -f3-)
               ./configure --with-kerneldir=/usr/src/kernels/${kernel_ver}
               make
-            displayName: Build CentOS
+            displayName: Build on CentOS
             condition: contains(variables['build_container'], 'centos')
 
           - bash: |
@@ -100,13 +101,15 @@ stages:
               kernel_ver=$(dpkg -l | grep 'linux-headers-.*-generic' | awk '{print $2}')
               ./configure --enable-gtest --with-kerneldir=/usr/src/${kernel_ver}
               make
-            displayName: Build Ubuntu
+            displayName: Build on Ubuntu
             condition: contains(variables['build_container'], 'ubuntu')
 
-  - stage: Test
+  - stage: VMs
+    displayName: Build & Test on VMs
     dependsOn: Codestyle
     jobs:
       - job: Test
+        timeoutInMinutes: 240
         workspace:
           clean: all
         pool:
@@ -124,6 +127,9 @@ stages:
               BOX_NAME: ubuntu2004
             ubuntu22:
               BOX_NAME: ubuntu2204
+            ubuntu22-mainline:
+              BOX_NAME: ubuntu2204
+              KERNEL: mainline
 
         steps:
           - checkout: self
@@ -153,8 +159,13 @@ stages:
             workingDirectory: $(System.DefaultWorkingDirectory)/ci/vm/
 
           - bash: |
+              set -x
+              hostname
+              export VAGRANT_HOME=/opt/vagrant_home
               vagrant destroy -f
               vagrant global-status --prune
+              virsh destroy vm_${BOX_NAME} || true
+              virsh undefine vm_${BOX_NAME} || true
             condition: always()
             displayName: Bring down VM
             workingDirectory: $(System.DefaultWorkingDirectory)/ci/vm/

--- a/ci/vm/Vagrantfile
+++ b/ci/vm/Vagrantfile
@@ -1,13 +1,25 @@
 #!/usr/bin/env ruby
+kernel_val = ENV['KERNEL'] || "null"
 
 Vagrant.configure("2") do |config|
   config.vm.box = "generic/#{ENV['BOX_NAME']}"
-  config.vm.provision "shell", :path => "entrypoint.sh", args: "#{ENV['BOX_NAME']} #{ENV['SYSTEM_PULLREQUEST_PULLREQUESTNUMBER']}"
+  config.vm.provision "shell", 
+                        path: "provision1.sh", 
+                        args: "#{ENV['BOX_NAME']} #{kernel_val}"
+
+  if ENV['KERNEL'] == 'mainline'
+    config.vm.provision :reload
+  end
+
+  config.vm.provision "shell", 
+                        path: "provision2.sh", 
+                        args: "#{ENV['BOX_NAME']} #{kernel_val} #{ENV['SYSTEM_PULLREQUEST_PULLREQUESTNUMBER']}"
+
   config.vm.define "#{ENV['BOX_NAME']}" do |vm01|
     vm01.vm.provider :libvirt do |libvirt|
-    vm01.vm.box_check_update = false
-        libvirt.memory = 8192
-        libvirt.cpus = 8
+      vm01.vm.box_check_update = false
+      libvirt.memory = 8192
+      libvirt.cpus = 8
     end
   end
 end

--- a/ci/vm/provision1.sh
+++ b/ci/vm/provision1.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -Exeuo pipefail
+
+OS=$1
+KERNEL=$2
+
+install_packages() {
+  if [[ $OS == *"ubuntu"* ]]; then
+    apt-get update &&
+      DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+        automake \
+        dkms \
+        git \
+        libtool &&
+      apt-get clean && rm -rf /var/lib/apt/lists/*
+  elif [[ $OS == *"centos"* ]]; then
+    yum install -y -q centos-release-scl
+    yum install -y -q \
+      automake \
+      devtoolset-8-gcc \
+      devtoolset-8-gcc-c++ \
+      elfutils-libelf-devel \
+      git \
+      libtool \
+      make &&
+      yum clean all
+  fi
+}
+
+install_mainline_kernel() {
+    uname -r
+    add-apt-repository ppa:cappelikan/ppa    
+    apt-get update &&
+      DEBIAN_FRONTEND=noninteractive apt-get install -yq mainline
+    mainline --install-latest -y
+}
+
+
+err_report() {
+  echo "Exited with ERROR in line $1"
+}
+trap 'err_report $LINENO' ERR
+
+install_packages
+if [[ $KERNEL == "mainline" ]]; then
+  install_mainline_kernel
+fi

--- a/ci/vm/provision1.sh
+++ b/ci/vm/provision1.sh
@@ -32,7 +32,8 @@ install_mainline_kernel() {
     add-apt-repository ppa:cappelikan/ppa    
     apt-get update &&
       DEBIAN_FRONTEND=noninteractive apt-get install -yq mainline
-    mainline --install-latest -y
+    mainline install-latest
+    echo $?
 }
 
 

--- a/ci/vm/provision2.sh
+++ b/ci/vm/provision2.sh
@@ -44,6 +44,9 @@ install_gcc() {
   GCC_VER=$(awk -F ' ' '{print $7}' /proc/version | cut -d'-' -f1)
   echo "INFO: Installing GCC ver $GCC_VER"
   wget -q https://ftp.gnu.org/gnu/gcc/gcc-"$GCC_VER"/gcc-"$GCC_VER".tar.xz
+  wget -q https://ftp.gnu.org/gnu/gcc/gcc-"$GCC_VER"/gcc-"$GCC_VER".tar.xz.sig
+  wget -q https://ftp.gnu.org/gnu/gnu-keyring.gpg
+  gpgv --keyring ./gnu-keyring.gpg gcc-"$GCC_VER".tar.xz.sig gcc-"$GCC_VER".tar.xz
   tar xf gcc-"$GCC_VER".tar.xz
   (cd gcc-"$GCC_VER" && ./contrib/download_prerequisites)
   mkdir gcc-build


### PR DESCRIPTION
## What
Compile and test XPMEM on the latest available kernel for Ubuntu.

## How
Introduced a new branch "ubuntu22-mainline" at the VMs matrix that does the following:
1. Install the latest kernel using the "mainline" utility.
2. Compile the exact GCC version that was used to compile the kernel installed.
3. Proceed to compile the Xpmem module using the newly installed GCC.
4. Test as usual.

### Sample build
https://dev.azure.com/ucfconsort/xpmem/_build/results?buildId=66903