### PR TITLE
KERNEL: Fix configure step by adding KBUILD_MODNAME string to compile…

### DIFF
--- a/m4/ac_path_kernel_source.m4
+++ b/m4/ac_path_kernel_source.m4
@@ -105,6 +105,7 @@ AC_DEFUN([AC_KERNEL_CHECKS],
   CPPFLAGS="-include $kerneldir/include/linux/kconfig.h \
             -include $kerneldir/include/linux/compiler.h \
             -D__KERNEL__ \
+            -DKBUILD_MODNAME=\"xpmem_configure\" \
             -I$kerneldir/include \
             -I$kerneldir/include/uapi \
             -I$kerneldir/arch/$srcarch/include \


### PR DESCRIPTION
In some cases, `KBUILD_MODNAME` is needed to proceed with configure script. Currently it seems to be:
-  kernel configured with `CONFIG_DYNAMIC_DEBUG_*`,