### PR TITLE
KERNEL: Use pte offset kernel function for mapped pages

### DIFF
--- a/kernel/xpmem_pfn.c
+++ b/kernel/xpmem_pfn.c
@@ -164,7 +164,7 @@ xpmem_vaddr_to_pte_offset(struct mm_struct *mm, u64 vaddr, u64 *offset)
 	}
 #endif
 
-	pte = pte_offset_map(pmd, vaddr);
+	pte = pte_offset_kernel(pmd, vaddr);
 	if (!pte_present(*pte))
 		return NULL;
 
@@ -218,7 +218,7 @@ xpmem_vaddr_to_pte_size(struct mm_struct *mm, u64 vaddr, u64 *size)
 		return NULL;
 	}
 
-	pte = pte_offset_map(pmd, vaddr);
+	pte = pte_offset_kernel(pmd, vaddr);
 	if (!pte_present(*pte)) {
 		*size = PAGE_SIZE;
 		return NULL;


### PR DESCRIPTION
Modules built against kernel 6.5 cannot use `pte_offset_map()`. Use directly the underlying `pte_offset_kernel()`, since we were never calling the corresponding `pte_offset_unmap()` anyways.