### PR TITLE
KERNEL: Fix v6.9 build: Use pmd_leaf()/pud_leaf() and pte_offset_kernel()

### DIFF
--- a/kernel/xpmem_main.c
+++ b/kernel/xpmem_main.c
@@ -400,7 +400,7 @@ static struct miscdevice xpmem_dev_handle = {
 /*
  * Initialize the XPMEM driver.
  */
-int __init
+static int __init
 xpmem_init(void)
 {
 	int i, ret;
@@ -488,7 +488,7 @@ out_1:
 /*
  * Remove the XPMEM driver from the system.
  */
-void __exit
+static void __exit
 xpmem_exit(void)
 {
 	kfree(xpmem_my_part);

--- a/kernel/xpmem_pfn.c
+++ b/kernel/xpmem_pfn.c
@@ -37,7 +37,18 @@
 #endif
 #endif
 
+#ifndef HAVE_PTE_MAP_OFFSET_MACRO
+#define pte_offset_map pte_offset_kernel
+#endif
+
 #if CONFIG_HUGETLB_PAGE
+
+#ifndef HAVE_PMD_LEAF_MACRO
+#define pmd_leaf pmd_large
+#endif
+#ifndef HAVE_PUD_LEAF_MACRO
+#define pud_leaf pud_large
+#endif
 
 #if (defined(CONFIG_ARM64) || defined(CONFIG_ARM))
 #define pmd_is_huge(p) pmd_sect(p)
@@ -47,10 +58,10 @@
 #define pud_is_huge(p) (0)
 #endif
 #elif defined(CONFIG_X86)
-#define pmd_is_huge(p) pmd_large(p)
-#define pud_is_huge(p) pud_large(p)
+#define pmd_is_huge(p) pmd_leaf(p)
+#define pud_is_huge(p) pud_leaf(p)
 #elif defined(CONFIG_PPC)
-#define pmd_is_huge(p) pmd_large(p)
+#define pmd_is_huge(p) pmd_leaf(p)
 #define pud_is_huge(p) ((pud_val(p) & 0x3) != 0x0)
 #else
 #error Unsuported architecture

--- a/m4/ac_path_kernel_source.m4
+++ b/m4/ac_path_kernel_source.m4
@@ -124,6 +124,16 @@ AC_DEFUN([AC_KERNEL_CHECKS],
     ], [], [[#include <linux/proc_fs.h>]])
   ], [[#include <linux/proc_fs.h>]])
 
+  AC_CHECK_DECL(pmd_leaf, [
+    AC_DEFINE([HAVE_PMD_LEAF_MACRO], 1, [Have pmd_leaf()])],
+    [], [[#include <linux/mm.h>]])
+  AC_CHECK_DECL(pud_leaf, [
+    AC_DEFINE([HAVE_PUD_LEAF_MACRO], 1, [Have pud_leaf()])],
+    [], [[#include <linux/mm.h>]])
+  AC_CHECK_DECL(pte_offset_map, [
+    AC_DEFINE([HAVE_PTE_OFFSET_MAP_MACRO], 1, [Have pte_offset_map()])],
+    [], [[#include <linux/mm.h>]])
+
   AC_CHECK_DECLS([vma_iter_init], [], [], [[#include <linux/mm_types.h>]])
 
   AC_MSG_CHECKING(latest apply_to_page_range support)


### PR DESCRIPTION
To support kernel 6.9+:
- Use pmd_leaf/pud_leaf and fallback to pmd_large/pud_large for older versions
- Preserve pte_offset_map usage and use pte_offset_kernel for later versions