### PR TITLE
KERNEL: Fix pte_offset_map() macro typo

### DIFF
--- a/kernel/xpmem_pfn.c
+++ b/kernel/xpmem_pfn.c
@@ -37,7 +37,7 @@
 #endif
 #endif
 
-#ifndef HAVE_PTE_MAP_OFFSET_MACRO
+#ifndef HAVE_PTE_OFFSET_MAP_MACRO
 #define pte_offset_map pte_offset_kernel
 #endif
 


### PR DESCRIPTION
Fix macro redefinition error on 5.15 when compiler translates warnings to errors.
- Internal: [3959386](https://redmine.mellanox.com/issues/3959386)

Warnings were actually seen on CI, preparing next PR to set them to error.