### PR TITLE
BUILD: Fix various build warnings

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -96,6 +96,8 @@ stages:
               set -eEx
               ./autogen.sh
               kernel_ver=$(rpm -qa | grep kernel-devel | cut -d'-' -f3-)
+              export CFLAGS='-Werror -Wall'
+              export KFLAGS='-Werror'
               ./configure --with-kerneldir=/usr/src/kernels/${kernel_ver}
               make
             displayName: Build on CentOS
@@ -105,6 +107,8 @@ stages:
               set -eEx
               ./autogen.sh
               kernel_ver=$(dpkg -l | grep 'linux-headers-.*-generic' | awk '{print $2}')
+              export CFLAGS='-Werror -Wall'
+              export KFLAGS='-Werror'
               ./configure --enable-gtest --with-kerneldir=/usr/src/${kernel_ver}
               make
             displayName: Build on Ubuntu

--- a/ci/vm/provision2.sh
+++ b/ci/vm/provision2.sh
@@ -4,6 +4,9 @@ set -Exeuo pipefail
 OS=$1
 PR_NUM=$2
 
+export CFLAGS="-Werror -Wall"
+export KFLAGS="-Werror"
+
 xpmem_build() {
   uname -r
   gcc --version

--- a/kernel/Makefile.am
+++ b/kernel/Makefile.am
@@ -19,8 +19,8 @@ EXTRA_DIST = ${module_sources}
 
 module_DATA = $(MODULE)
 
-
-KCPPFLAGS = -include @abs_top_builddir@/config.h -I@abs_top_srcdir@/include
+KCPPFLAGS = -include @abs_top_builddir@/config.h -I@abs_top_srcdir@/include \
+	    $(KFLAGS)
 export KCPPFLAGS
 
 $(MODULE): ${module_sources}

--- a/kernel/xpmem_private.h
+++ b/kernel/xpmem_private.h
@@ -268,7 +268,7 @@ struct xpmem_partition {
  */
 #define XPMEM_MAX_PAGE_FAULT_AFTER 32
 #define XPMEM_MAX_PAGE_FAULT_BEFORE 16
-#define XPMEM_MAX_PAGE_FAULTS 128
+#define XPMEM_MAX_PAGE_FAULTS 96
 
 struct xpmem_config {
 	rwlock_t lock;

--- a/m4/ac_path_kernel_source.m4
+++ b/m4/ac_path_kernel_source.m4
@@ -101,7 +101,9 @@ AC_DEFUN([AC_KERNEL_CHECKS],
                            -e s/sparc32.*/sparc/ \
                            -e s/sparc64.*/sparc/ \
                            -e s/s390x/s390/)
+  save_CFLAGS="$CFLAGS"
   save_CPPFLAGS="$CPPFLAGS"
+  CFLAGS=
   CPPFLAGS="-include $kerneldir/include/linux/kconfig.h \
             -include $kerneldir/include/linux/compiler.h \
             -D__KERNEL__ \
@@ -148,6 +150,8 @@ AC_DEFUN([AC_KERNEL_CHECKS],
 
   AC_CHECK_DECLS([vm_flags_set], [], [], [[#include <linux/mm.h>]])
 
+  AC_SUBST(KFLAGS, [$KFLAGS])
   CPPFLAGS="$save_CPPFLAGS"
+  CFLAGS="$save_CFLAGS"
 ]
 )

--- a/test/share/include/xpmem_test.h
+++ b/test/share/include/xpmem_test.h
@@ -6,9 +6,9 @@
 
 #define NR_TEST_PAGES 	4
 #define PAGE_SIZE	page_size()
-#define SHARE_SIZE	NR_TEST_PAGES * PAGE_SIZE
-#define PAGE_INT_SIZE	(PAGE_SIZE / sizeof(int))
-#define SHARE_INT_SIZE	(SHARE_SIZE / sizeof(int))
+#define SHARE_SIZE	(NR_TEST_PAGES * PAGE_SIZE)
+#define PAGE_INT_SIZE	((int)(PAGE_SIZE / sizeof(int)))
+#define SHARE_INT_SIZE	((int)(SHARE_SIZE / sizeof(int)))
 
 /* Used to specify size of /tmp/xpmem.share */
 #define TMP_SHARE_SIZE	32
@@ -46,7 +46,7 @@ xpmem_segid_t make_share(int **data, size_t size)
 		return -1;
 	}
 
-	for (i=0; i < (size / sizeof(int)); i++)
+	for (i=0; i < (int)(size / sizeof(int)); i++)
 		*(ptr + i) = i;
 
 	segid = xpmem_make(ptr, size, XPMEM_PERMIT_MODE, (void *)0666);

--- a/test/share/xpmem_master.c
+++ b/test/share/xpmem_master.c
@@ -21,12 +21,12 @@
 		printf("==== %s PASSED ====\n\n", (name)) :	\
 		printf("==== %s FAILED ====\n\n", (name)))
 
-int test_base(test_args* t) { return 0; }
-int test_two_attach(test_args* t) { return 0; }
-int test_two_shares(test_args* t) { return 0; }
-int test_fork(test_args* t) { return 0; }
+int test_base(test_args* t) { (void)t; return 0; }
+int test_two_attach(test_args* t) { (void)t; return 0; }
+int test_two_shares(test_args* t) { (void)t; return 0; }
+int test_fork(test_args* t) { (void)t; return 0; }
 
-int main(int argc, char** argv)
+int main(void)
 {
 	pid_t p1, p2;
 	int i, fd, lock, status[2];

--- a/test/share/xpmem_proc2.c
+++ b/test/share/xpmem_proc2.c
@@ -198,7 +198,7 @@ int test_fork(test_args *xpmem_args)
 	printf("xpmem_proc2: reading to pin pages\n");
 	for (i = 0; i < PAGE_INT_SIZE; i++) {
 		if (*(data + i) != PAGE_INT_SIZE + i) {
-			printf("xpmem_proc2: ***mismatch at %d: expected %lu "
+			printf("xpmem_proc2: ***mismatch at %d: expected %d "
 				"got %d\n", i, PAGE_INT_SIZE + i, *(data + i));
 			ret = -2;
 		}


### PR DESCRIPTION
Turn warnings into errors when building in CI.

Usage:
```
KFLAGS=-Werror CFLAGS='-Wall -Werror' ./configure
make
<or, to override configure time value>
make KFLAGS='-Wextra -Werror'
```