### PR TITLE
DKMS: Support build and install for multiple kernel sources

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 autoreconf -ivf || exit 1

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -114,6 +114,16 @@ stages:
             displayName: Build on Ubuntu
             condition: contains(variables['build_container'], 'ubuntu')
 
+          - bash: |
+              set -eEx
+              make -i clean || true
+              tar --transform='s/^\./xpmem-dkms\//g' -czvf ../xpmem-dkms.tgz .
+              sudo dkms ldtarball ../xpmem-dkms.tgz
+              module=`dkms status | awk 'BEGIN { FS="," } /xpmem/ { print $1 }'`
+              sudo dkms build "$module"
+            displayName: DKMS module build on Ubuntu
+            condition: contains(variables['build_container'], 'ubuntu')
+
   - stage: VMs
     displayName: Build & Test on VMs
     dependsOn: Codestyle

--- a/dkms.conf
+++ b/dkms.conf
@@ -13,7 +13,7 @@ BUILT_MODULE_LOCATION[0]="kernel"
 # where we put it under the kernel modules directory
 DEST_MODULE_LOCATION[0]="/kernel/../updates/"
 # how to build it
-MAKE[0]="./configure --prefix=/opt/xpmem; make clean; make install"
+MAKE[0]="./configure --with-kerneldir=$kernel_source_dir --with-kernelvers=$kernelver ; make"
 
 # clean up command
 CLEAN="make distclean"

--- a/dkms.conf
+++ b/dkms.conf
@@ -6,6 +6,11 @@
 PACKAGE_NAME="xpmem"
 PACKAGE_VERSION="2.7.3"
 
+# Need to check if the configure script exists and run autogen.sh if it doesn't.
+# This has to be in a standalone script because DKMS does not support shell
+# commands in PRE_BUILD nor passing any argument.
+PRE_BUILD="dkms_prebuild.sh"
+
 # module name
 BUILT_MODULE_NAME[0]="xpmem"
 # where we find the .ko file under the build directory

--- a/dkms_prebuild.sh
+++ b/dkms_prebuild.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+test -x configure || ./autogen.sh


### PR DESCRIPTION
Currently, the `dkms.conf`

* Requires that `autogen.sh` be run on the directory first (prevents just giving the source tarball to dkms directly with `dkms ldtarball TARBALL`).
* Attempts to autodetect the kernel rather than use what DKMS indicates the kernel should be (build would not work well if more than one kernel is installed)
* Installs the library and headers even though only the module should be installed.

The `dkms.conf` file was changed to

* Run `autogen.sh` as the `PRE_BUILD` step
* Set the kernel directory and version with the information from DKMS
* Not run `make install` when building (means only the module will get installed after DKMS finds it). This also means that no install path is baked in.
* Removes comments about stuff the `dkms.conf` doesn't actually do

The one catch is that with these changes, the library and headers must be installed separately.

With this, one could download the source tarball and immediately do

```bash
dkms ldtarball xpmem-VERSION.tgz
dkms install xpmem/VERSION --all
```

and have the module be built for all kernels.