### PR TITLE
BUILD: Fix kernel source search path on RHEL8

### DIFF
--- a/m4/ac_path_kernel_source.m4
+++ b/m4/ac_path_kernel_source.m4
@@ -18,6 +18,7 @@ AC_DEFUN([AC_PATH_KERNEL_SOURCE_SEARCH],
       /lib/modules/${kernelvers}/build \
       /lib/modules/${kernelvers}/source \
       /usr/src/linux-source-${kernelvers} \
+      /usr/src/kernels/${kernelvers} \
       /usr/src/kernel-source-* \
       /usr/src/linux
   do


### PR DESCRIPTION
RHEL/CentOS/Rocky/Alma/etc. 8 distros (RHEL/CentOS/Rocky/Alma/etc. 9 as well) install kernel sources at `/usr/src/kernels/KERNELVERSION`. This path pattern is added to the `AC_PATH_KERNEL_SOURCE_SEARCH` autoconf macro for finding the kernel source directory on these distros.