### PR TITLE
BUILD: don't run kernel checks if not building the kernel module

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -114,6 +114,26 @@ stages:
             displayName: Build on Ubuntu
             condition: contains(variables['build_container'], 'ubuntu')
 
+          - bash: |
+              set -eEx
+              test -f Makefile && make -i distclean || true
+              ./autogen.sh
+              export CFLAGS='-Werror -Wall'
+              ./configure --disable-kernel-module
+              make
+            displayName: Build on CentOS without kernel module
+            condition: contains(variables['build_container'], 'centos')
+
+          - bash: |
+              set -eEx
+              test -f Makefile && make -i distclean || true
+              ./autogen.sh
+              export CFLAGS='-Werror -Wall'
+              ./configure --enable-gtest --disable-kernel-module
+              make
+            displayName: Build on Ubuntu without kernel module
+            condition: contains(variables['build_container'], 'ubuntu')
+
   - stage: VMs
     displayName: Build & Test on VMs
     dependsOn: Codestyle

--- a/configure.ac
+++ b/configure.ac
@@ -68,7 +68,6 @@ AC_SUBST([initdir], [${sysconfdir}/init.d])
 AC_SUBST([ldsoconfdir], [/etc/ld.so.conf.d])
 AC_SUBST([pkgconfigdir], [${libdir}/pkgconfig])
 
-AC_PATH_KERNEL_SOURCE
 AC_KERNEL_CHECKS
 
 AC_CONFIG_FILES([Makefile

--- a/m4/ac_kernel_checks.m4
+++ b/m4/ac_kernel_checks.m4
@@ -42,13 +42,16 @@ AC_DEFUN([AC_PATH_KERNEL_SOURCE_SEARCH],
 ]
 )
 
-AC_DEFUN([AC_PATH_KERNEL_SOURCE],
+AC_DEFUN([AC_KERNEL_CHECKS],
 [
   AC_CHECK_PROG(ac_pkss_mktemp,mktemp,yes,no)
-  AC_PROVIDE([AC_PATH_KERNEL_SOURCE])
+  AC_PROVIDE([AC_KERNEL_CHECKS])
 
-  AC_ARG_ENABLE([kernel-module],[Enable building the kernel module (default: enabled)],[build_kernel_module=$enableval],
-		[build_kernel_module=1])
+  AC_ARG_ENABLE([kernel-module],
+    [AS_HELP_STRING([--disable-kernel-module],
+                    [Disable building the kernel module (default is enabled)],)],
+    [build_kernel_module=$enableval],
+    [build_kernel_module=1])
   AS_IF([test $build_kernel_module = 1],[
 
   AC_MSG_CHECKING([for Linux kernel sources])
@@ -88,12 +91,14 @@ AC_DEFUN([AC_PATH_KERNEL_SOURCE],
 
   AC_MSG_CHECKING([kernel release])
   AC_MSG_RESULT([${kernelvers}])
+
+  AC_KERNEL_CHECK_SUPPORT
   ])
   AM_CONDITIONAL([BUILD_KERNEL_MODULE], [test $build_kernel_module = 1])
 ]
 )
 
-AC_DEFUN([AC_KERNEL_CHECKS],
+AC_DEFUN([AC_KERNEL_CHECK_SUPPORT],
 [
   srcarch=$(uname -m | sed -e s/i.86/x86/ \
                            -e s/x86_64/x86/ \


### PR DESCRIPTION
This is continuation of #60 prepared by @frejanordsiek for merge.