### PR TITLE
BUILD: Generate userspace RPMs in CI

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ sysconf_DATA = .version \
 EXTRA_DIST = \
 	56-xpmem.rules \
 	$(pkgconfig_DATA) \
-	xpmem-lib.spec \
+	xpmem.spec \
 	xpmem-kmod.spec \
 	dkms.conf \
 	debian

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -197,6 +197,22 @@ stages:
             displayName: Debian userspace packaging
             condition: contains(variables['build_container'], 'ubuntu')
 
+          - bash: |
+              set -eEx
+              test -f Makefile && make -i distclean || true
+              sudo apt-get update
+              sudo apt-get install -y rpm
+              mkdir {BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+              sed -i '/BuildRequires/d' xpmem.spec
+              ./autogen.sh
+              ./configure --disable-kernel-module
+              make dist-gzip
+              mv xpmem-*.tar.* ./SOURCES/
+              rpmbuild --define "_topdir $PWD" -ba xpmem.spec
+              find RPMS SRPMS
+            displayName: Build userspace RPMs on CentOS
+            condition: contains(variables['build_container'], 'ubuntu18')
+
   - stage: VMs
     displayName: Build & Test on VMs
     dependsOn: Codestyle

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.63])
-AC_INIT([xpmem], [2.7], [http://github.com/openucx/xpmem/issues])
+AC_INIT([xpmem], [2.7.3], [http://github.com/openucx/xpmem/issues])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AC_CONFIG_SRCDIR([include/xpmem.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/xpmem.spec
+++ b/xpmem.spec
@@ -5,7 +5,7 @@
 %global debug_package %{nil}
 
 Summary: XPMEM: Cross-partition memory
-Name: xpmem-lib
+Name: xpmem
 Version: 2.7.3
 Release: 1
 License: LGPLv2.1


### PR DESCRIPTION
Generate SRPMS and RPMS in CI with latest `xpmem-lib.spec` file merged by #63.


```
$ find SRPMS/ RPMS/
SRPMS/xpmem-2.7.3-1.src.rpm
RPMS/x86_64/libxpmem-2.7.3-1.x86_64.rpm
RPMS/x86_64/libxpmem-devel-2.7.3-1.x86_64.rpm

$ rpm -qi RPMS/x86_64/libxpmem-devel-2.7.3-1.x86_64.rpm
Name        : libxpmem-devel
Version     : 2.7.3
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : System Environment/Libraries
Size        : 11654
License     : LGPLv2.1
Signature   : (none)
Source RPM  : xpmem-2.7.3-1.src.rpm
Build Date  : Wed 11 Sep 2024 09:11:49 PM IDT
Build Host  : lab-machine
Packager    : Nathan Hjelm
Summary     : XPMEM: user-space library headers
Description :
XPMEM is a Linux kernel module that enables a process to map the
memory of another process into its virtual address space. Source code
can be obtained by cloning the Git repository, original Mercurial
repository or by downloading a tarball from the link above.

This package contains the development headers for the user-space library
needed to interface with XPMEM.
```