### PR TITLE
BUILD: Add DKMS RPM package

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,7 @@ EXTRA_DIST = \
 	$(pkgconfig_DATA) \
 	xpmem-lib.spec \
 	xpmem-kmod.spec \
+	xpmem-dkms.spec \
 	dkms.conf \
 	debian
 

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -140,6 +140,36 @@ stages:
               # - https://github.com/dell/dkms/commit/468025752343dbc8609704bf0915f52b9c5c50f2
               sudo sed -i  -e 's@if \[\[ ! $temp_dir_name/dkms_main_tree \]\]@if \[\[ ! -d $temp_dir_name/dkms_main_tree \]\]@g' /usr/sbin/dkms || true
 
+              git clean -xdf
+              ./autogen.sh
+              ./configure --disable-kernel-module
+              make dist-gzip
+
+              sudo dkms ldtarball ./xpmem-*.tar.gz
+              dkms status -m xpmem
+              version=$(dkms status -m xpmem | sed -n -e 's@xpmem[,/ ]\+\([^:,]\+\).*@\1@p')
+              kernel_ver=$(rpm -qa | grep kernel-devel | cut -d'-' -f3-)
+              sudo dkms build xpmem/${version} --kernelsourcedir=/usr/src/kernels/${kernel_ver} -k ${kernel_ver}
+              # Workaround DKMS limitation
+              sudo dkms build xpmem/${version} --kernelsourcedir=/usr/src/kernels/${kernel_ver} -k $(uname -r)
+
+              rpmbuild --define "_topdir $PWD" -bb xpmem-dkms.spec
+
+              sudo dkms remove "xpmem/$version" --all || true
+              sudo rm -rf /var/lib/dkms/xpmem/$version/
+              sudo rm -rf /usr/src/xpmem-*
+
+              sudo rpm -qplvi RPMS/noarch/xpmem-${version}-dkms.noarch.rpm
+
+            displayName: DKMS module build on Centos
+            condition: contains(variables['build_container'], 'centos')
+
+          - bash: |
+              set -eEx
+              # Workaround DKMS issue:
+              # - https://github.com/dell/dkms/commit/468025752343dbc8609704bf0915f52b9c5c50f2
+              sudo sed -i  -e 's@if \[\[ ! $temp_dir_name/dkms_main_tree \]\]@if \[\[ ! -d $temp_dir_name/dkms_main_tree \]\]@g' /usr/sbin/dkms || true
+
               # dkms needs 'make mrproper' to work properly
               sudo apt-get update
               sudo DEBIAN_FRONTEND=noninteractive apt-get install -y bison flex git debhelper

--- a/xpmem-dkms.spec
+++ b/xpmem-dkms.spec
@@ -1,0 +1,50 @@
+%{?!_dkmsdir: %define _dkmsdir /var/lib/dkms}
+
+%define module xpmem
+%define version 2.7.3
+
+Summary: XPMEM: Cross-partition memory dkms package
+Name: %{module}
+Version: %{version}
+Release: dkms
+BuildArch: noarch
+License: GPLv2
+Group: System Environment/Kernel
+Requires: dkms >= 1.95 gcc bash sed flex bison
+
+%description
+XPMEM is a Linux kernel module that enables a process to map the
+memory of another process into its virtual address space. Source code
+can be obtained by cloning the Git repository, original Mercurial
+repository or by downloading a tarball from the link above.
+
+%prep
+sudo /usr/sbin/dkms mktarball -m %module -v %version --archive `basename %{module}-%{version}.dkms.tar.gz`
+cp -af %{_dkmsdir}/%{module}/%{version}/tarball/`basename %{module}-%{version}.dkms.tar.gz` %{module}-%{version}.dkms.tar.gz
+
+%install
+[ "$RPM_BUILD_ROOT" != "/" ] && rm -rf $RPM_BUILD_ROOT
+mkdir -p $RPM_BUILD_ROOT/%{_datarootdir}/%{module}
+install -m 644 %{module}-%{version}.dkms.tar.gz $RPM_BUILD_ROOT/%{_datarootdir}/%{module}
+
+%clean
+#[ "$RPM_BUILD_ROOT" != "/" ] && rm -rf $RPM_BUILD_ROOT
+
+%post
+/usr/sbin/dkms ldtarball %{_datarootdir}/%{module}/%{module}-%{version}.dkms.tar.gz
+/usr/sbin/dkms build -m %{module} -v %{version} --force
+/usr/sbin/dkms install -m %{module} -v %{version}
+exit 0
+
+%preun
+echo -e "Uninstalling %{module} module (version %{version}):"
+/usr/sbin/dkms remove -m %{module} -v %{version} --all --rpm_safe_upgrade
+exit 0
+
+%files
+%defattr(-,root,root)
+/%{_datarootdir}/%{module}/%{module}-%{version}.dkms.tar.gz
+
+%changelog
+* %(date "+%a %b %d %Y") %{version}-%{release}
+- Built from DKMS


### PR DESCRIPTION
Add spec file to produce dkms rpm.

```
$ rpm -qplpvi RPMS/noarch/xpmem-2.7.3-dkms.noarch.rpm
Name        : xpmem
Version     : 2.7.3
Release     : dkms
Architecture: noarch
Install Date: (not installed)
Group       : System Environment/Kernel
Size        : 783489
License     : GPLv2
Signature   : (none)
Source RPM  : xpmem-2.7.3-dkms.src.rpm
Build Date  : Fri 20 Sep 2024 06:24:52 PM IDT
Build Host  : mtr-vdi-414.wap.labs.mlnx
Summary     : XPMEM: Cross-partition memory dkms package
Description :
XPMEM is a Linux kernel module that enables a process to map the
memory of another process into its virtual address space. Source code
can be obtained by cloning the Git repository, original Mercurial
repository or by downloading a tarball from the link above.
-rw-r--r--    1 root     root                   783489 Sep 20 03:00 /usr/share/xpmem/xpmem-2.7.3.dkms.tar.gz
```