### PR TITLE
BUILD: Detect get_user_pages_remote version

### DIFF
--- a/kernel/xpmem_pfn.c
+++ b/kernel/xpmem_pfn.c
@@ -373,19 +373,19 @@ xpmem_pin_pages(struct xpmem_thread_group *tg, struct task_struct *src_task,
 	foll_write = (vma->vm_flags & VM_WRITE) ? FOLL_WRITE : 0;
 
 	/* get_user_pages()/get_user_pages_remote() faults and pins the page */
-#if     LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+#ifdef HAVE_GUP_6_5
 	nr_pinned = get_user_pages_remote (src_mm, vaddr, count, foll_write, pages,
 				     NULL);
-#elif   LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
+#elif defined(HAVE_GUP_5_9)
 	nr_pinned = get_user_pages_remote (src_mm, vaddr, count, foll_write, pages,
 				     NULL, NULL);
-#elif   LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0)
+#elif defined(HAVE_GUP_4_10)
 	nr_pinned = get_user_pages_remote (src_task, src_mm, vaddr, count,
 				     foll_write, pages, NULL, NULL);
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
+#elif defined(HAVE_GUP_4_9)
 	nr_pinned = get_user_pages_remote (src_task, src_mm, vaddr, count,
 				     foll_write, pages, NULL);
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)
+#elif defined(HAVE_GUP_4_8)
 	nr_pinned = get_user_pages_remote (src_task, src_mm, vaddr, count,
 				     foll_write, 0, pages, NULL);
 #else


### PR DESCRIPTION
Some distribution kernels have backports so we cannot always rely on the kernel version to determine the proper function prototype to use.

Internal: [4100109](https://redmine.mellanox.com/issues/4100109)


Note slight behavior change for centos7, where we go from using `get_user_pages()` to `get_user_pages_remote()` as it is already available, there might be other cases:
```
/usr/src/kernels/3.10.0-1160.119.1.el7.x86_64/include/linux/mm.h:long get_user_pages_remote(struct task_struct *tsk, struct mm_struct *mm,
```