### PR TITLE
BUILD: Centralize xpmem version specification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@ kernel/Module.symvers
 kernel/Kbuild
 .tmp_versions
 test-driver
+dkms.conf
+debian/changelog
+xpmem-dkms.spec
+xpmem-kmod.spec
+xpmem.spec

--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,11 @@ AC_KERNEL_CHECKS
 
 AC_CONFIG_FILES([Makefile
                  cray-xpmem.pc
+                 dkms.conf
+                 debian/changelog
+                 xpmem-dkms.spec
+                 xpmem-kmod.spec
+                 xpmem.spec
                  module
                  include/Makefile
                  kernel/Kbuild

--- a/debian/changelog.in
+++ b/debian/changelog.in
@@ -1,4 +1,4 @@
-xpmem-lib (2.7.3) unstable; urgency=medium
+xpmem-lib (@PACKAGE_VERSION@) unstable; urgency=medium
 
   * Initial release.
 

--- a/dkms.conf.in
+++ b/dkms.conf.in
@@ -4,7 +4,7 @@
 
 # DKMS module name and version
 PACKAGE_NAME="xpmem"
-PACKAGE_VERSION="2.7.3"
+PACKAGE_VERSION="@PACKAGE_VERSION@"
 
 # module name
 BUILT_MODULE_NAME[0]="xpmem"

--- a/kernel/xpmem_main.c
+++ b/kernel/xpmem_main.c
@@ -511,6 +511,6 @@ MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Silicon Graphics, Inc.");
 MODULE_INFO(supported, "external");
 MODULE_DESCRIPTION("XPMEM support");
-MODULE_VERSION("2.7.3");
+MODULE_VERSION(XPMEM_CURRENT_VERSION_STRING);
 module_init(xpmem_init);
 module_exit(xpmem_exit);

--- a/kernel/xpmem_private.h
+++ b/kernel/xpmem_private.h
@@ -70,7 +70,7 @@
  *       minor - minor revision number (16-bits)
  */
 #define XPMEM_CURRENT_VERSION		0x00027003
-#define XPMEM_CURRENT_VERSION_STRING	"2.7.3"
+#define XPMEM_CURRENT_VERSION_STRING	PACKAGE_VERSION
 
 #define XPMEM_MODULE_NAME "xpmem"
 

--- a/xpmem-dkms.spec.in
+++ b/xpmem-dkms.spec.in
@@ -1,7 +1,7 @@
 %{?!_dkmsdir: %define _dkmsdir /var/lib/dkms}
 
 %define module xpmem
-%define version 2.7.3
+%define version @PACKAGE_VERSION@
 
 Summary: XPMEM: Cross-partition memory dkms package
 Name: %{module}

--- a/xpmem-kmod.spec.in
+++ b/xpmem-kmod.spec.in
@@ -3,7 +3,7 @@
 #define buildforkernels akmod
 
 %define module xpmem
-%define version 2.7.3
+%define version @PACKAGE_VERSION@
 
 %global debug_package %{nil}
 %define _unpackaged_files_terminate_build 0

--- a/xpmem.spec.in
+++ b/xpmem.spec.in
@@ -6,7 +6,7 @@
 
 Summary: XPMEM: Cross-partition memory
 Name: xpmem
-Version: 2.7.3
+Version: @PACKAGE_VERSION@
 Release: 1
 License: LGPLv2.1
 Group: System Environment/Libraries


### PR DESCRIPTION
Use xpmem version specified in `configure.ac`. Remains one other entry in hexadecimal in `xpmem_main.c`. Check with `modinfo kernel/xpmem.ko` to check version used.