### PR TITLE
BUILD: Restore using default CFLAGS for kernel checks

### DIFF
--- a/m4/ac_kernel_checks.m4
+++ b/m4/ac_kernel_checks.m4
@@ -159,7 +159,7 @@ AC_DEFUN([AC_KERNEL_CHECK_SUPPORT],
                            -e s/s390x/s390/)
   save_CFLAGS="$CFLAGS"
   save_CPPFLAGS="$CPPFLAGS"
-  CFLAGS="$KERNEL_CHECKS_CFLAGS"
+  CFLAGS="${KERNEL_CHECKS_CFLAGS:--g -O2}"
   CPPFLAGS="-include $kernelinc/include/linux/kconfig.h \
             -include $kernelinc/include/linux/compiler.h \
             -D__KERNEL__ \


### PR DESCRIPTION
## What
Restore using default CFLAGS for kernel configuration, still allowing override in case needed.

## Why
PR #54 introduced the default clearing of `CFLAGS=`while checking for kernel features:
- [Clearing location](https://github.com/openucx/xpmem/pull/54/files#diff-207ed315adf67f221c2ccc97ed489791f8b3ef0b8ff09d65540bbef148251e4aR106)

This is causing issues on some platforms. In particular `-O2` seems to be needed to allow proper compilation. We need to directly use `-g -O2` as `CFLAGS` is now used for userspace.

Error seen on vdi 6.10.10-100.fc39.x86_64:
```
build/include/linux/compiler_types.h:445:20: error: impossible constraint in 'asm'
#define asm_inline asm __inline
```