### PR TITLE
kernel: alternative configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,8 @@ kernel/xpmem.mod.c
 kernel/xpmem.mod
 kernel/modules.order
 kernel/Module.symvers
-kernel/Kbuild
+kernel/test_mods/
+kernel/xpmem_kernel.h
 .tmp_versions
 test-driver
 dkms.conf

--- a/Makefile.am
+++ b/Makefile.am
@@ -27,3 +27,5 @@ EXTRA_DIST = \
 	echo "set ModulesVersion \"@MODULE_VERSION@\"" >> $@
 
 dist: dist-bzip2
+
+CLEANFILES = .version xpmem-*.tar.bz2

--- a/configure.ac
+++ b/configure.ac
@@ -79,7 +79,6 @@ AC_CONFIG_FILES([Makefile
                  xpmem.spec
                  module
                  include/Makefile
-                 kernel/Kbuild
                  kernel/Makefile
                  kernel/xpmem
                  lib/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -95,5 +95,8 @@ AC_CONFIG_LINKS([kernel/xpmem_attach.c:kernel/xpmem_attach.c
                  kernel/xpmem_mmu_notifier.c:kernel/xpmem_mmu_notifier.c
                  kernel/xpmem_pfn.c:kernel/xpmem_pfn.c
                  kernel/xpmem_private.h:kernel/xpmem_private.h
+                 kernel/Kbuild:kernel/Kbuild
+                 include/xpmem.h:include/xpmem.h
+                 include/xpmem_internal.h:include/xpmem_internal.h
                  test/share/run.sh:test/share/run.sh])
 AC_OUTPUT

--- a/debian/clean
+++ b/debian/clean
@@ -1,3 +1,2 @@
-kernel/Kbuild
 kernel/Makefile
 kernel/xpmem

--- a/dkms.conf.in
+++ b/dkms.conf.in
@@ -12,11 +12,11 @@ BUILT_MODULE_NAME[0]="xpmem"
 BUILT_MODULE_LOCATION[0]="kernel"
 # where we put it under the kernel modules directory
 DEST_MODULE_LOCATION[0]="/kernel/../updates/"
-# how to build it
-MAKE[0]="sh ./configure --with-kerneldir=$kernel_source_dir --with-kernelvers=$kernelver ; make"
+# how to build it (only build kernel module for DKMS)
+MAKE[0]='export KSRC=$kernel_source_dir; ./kernel/config_kernel && make -C kernel'
 
-# clean up command
-CLEAN="make distclean"
+## clean up command (only clean kernel module for DKMS)
+CLEAN="env KSRC=$kernel_source_dir make -C kernel clean"
 
 # rebuild and autoinstall automatically when dkms_autoinstaller runs
 # for a new kernel

--- a/dkms.conf.in
+++ b/dkms.conf.in
@@ -13,7 +13,7 @@ BUILT_MODULE_LOCATION[0]="kernel"
 # where we put it under the kernel modules directory
 DEST_MODULE_LOCATION[0]="/kernel/../updates/"
 # how to build it (only build kernel module for DKMS)
-MAKE[0]='export KSRC=$kernel_source_dir; ./kernel/config_kernel && make -C kernel'
+MAKE[0]='env KSRC=$kernel_source_dir ./kernel/config_kernel && make -C kernel KSRC=$kernel_source_dir'
 
 ## clean up command (only clean kernel module for DKMS)
 CLEAN="env KSRC=$kernel_source_dir make -C kernel clean"

--- a/dkms.conf.in
+++ b/dkms.conf.in
@@ -13,7 +13,7 @@ BUILT_MODULE_LOCATION[0]="kernel"
 # where we put it under the kernel modules directory
 DEST_MODULE_LOCATION[0]="/kernel/../updates/"
 # how to build it (only build kernel module for DKMS)
-MAKE[0]='env KSRC=$kernel_source_dir ./kernel/config_kernel && make -C kernel KSRC=$kernel_source_dir'
+MAKE[0]='./configure --with-kerneldir=$kernel_source_dir && make -C kernel KSRC=$kernel_source_dir'
 
 ## clean up command (only clean kernel module for DKMS)
 CLEAN="env KSRC=$kernel_source_dir make -C kernel clean"

--- a/dkms.conf.in
+++ b/dkms.conf.in
@@ -13,7 +13,7 @@ BUILT_MODULE_LOCATION[0]="kernel"
 # where we put it under the kernel modules directory
 DEST_MODULE_LOCATION[0]="/kernel/../updates/"
 # how to build it (only build kernel module for DKMS)
-MAKE[0]='./configure --with-kerneldir=$kernel_source_dir && make -C kernel KSRC=$kernel_source_dir'
+MAKE[0]='sh ./configure --with-kerneldir=$kernel_source_dir && make -C kernel KSRC=$kernel_source_dir'
 
 ## clean up command (only clean kernel module for DKMS)
 CLEAN="env KSRC=$kernel_source_dir make -C kernel clean"

--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -1,9 +1,9 @@
-
 obj-m		:= xpmem.o
 xpmem-objs	:= xpmem_main.o xpmem_make.o xpmem_get.o \
 		   xpmem_attach.o xpmem_pfn.o xpmem_misc.o \
 		   xpmem_mmu_notifier.o
-				
 
-EXTRA_CFLAGS = -DKERNEL_3_8 \
-               -I$(obj)/@top_srcdir@/include
+
+ccflags-y =	-DKERNEL_3_8 \
+	       -include $(obj)/xpmem_kernel.h \
+               -I$(obj)/../include

--- a/kernel/Makefile.am
+++ b/kernel/Makefile.am
@@ -19,10 +19,6 @@ EXTRA_DIST = ${module_sources}
 
 module_DATA = $(MODULE)
 
-KCPPFLAGS = -include @abs_top_builddir@/config.h -I@abs_top_srcdir@/include \
-	    $(KFLAGS)
-export KCPPFLAGS
-
 $(MODULE): ${module_sources}
 	$(MAKE) -C $(KERNEL_PATH) M=$(abs_builddir)
 
@@ -31,5 +27,6 @@ modules_install: $(MODULE)
 
 clean-local:
 	$(MAKE) -C $(KERNEL_PATH) M=$(abs_builddir) clean
+	rm -rf test_mods xpmem_kernel.h
 
 .PHONY: $(MODULE)

--- a/kernel/Makefile.am
+++ b/kernel/Makefile.am
@@ -6,6 +6,9 @@ init_SCRIPTS = xpmem
 MODULE=xpmem.ko
 
 module_sources = \
+    config_kernel \
+    Kbuild \
+    test_cases \
     xpmem_attach.c \
     xpmem_get.c \
     xpmem_main.c \

--- a/kernel/Makefile.dkms
+++ b/kernel/Makefile.dkms
@@ -1,0 +1,20 @@
+KVERS = $(shell uname -r)
+KSRC = /lib/modules/$(KVERS)/build
+KMAKE = make -C $(KSRC) M=$(shell pwd) # $(PWD) may point to main dir
+
+all:
+	$(KMAKE) modules
+
+clean:
+	$(KMAKE) clean
+
+.PHONY: all clean
+
+obj-m		:= xpmem.o
+xpmem-objs	:= xpmem_main.o xpmem_make.o xpmem_get.o \
+		   xpmem_attach.o xpmem_pfn.o xpmem_misc.o \
+		   xpmem_mmu_notifier.o
+
+ccflags-y =	-DKERNEL_3_8 \
+	       -include $(obj)/xpmem_kernel.h \
+               -I$(obj)/../include

--- a/kernel/config_kernel
+++ b/kernel/config_kernel
@@ -1,0 +1,207 @@
+#!/bin/sh
+
+# shellcheck disable=SC2006,SC3043,SC3037
+# Allows: local, echo -n, backtick syntax
+
+usage() {
+	cat <<EOF
+$0: configure kernel
+Usage:
+  $0                # Run configuration
+  $0  sanity        # Build and run sanity check
+  $0  CONFIG_NAME   # re-test configuration for CONFIG_NAME
+
+Options:
+
+-q  Run quietly. Only print errors
+-h  Print this message
+
+Kernel source is set by setting KSRC, KVERS or taken from uname -r
+EOF
+}
+
+set_ksrc() {
+	KVERS="${KVERS:-`uname -r`}"
+	KSRC=${KSRC:-/lib/modules/$KVERS/build}
+}
+
+set_globals() {
+	cd "`dirname "$0"`" || exit 2
+	set_ksrc
+	NJOBS=$(($(nproc)+1)) # FIXME: calibrate -j
+	TEST_MODULES_DIR="$PWD/test_mods"
+	TEST_CASES_DIR="$PWD/test_cases"
+	TEST_MOD_NAME="testmod"
+	TEST_RUN_LOG="$TEST_MODULES_DIR/run.log"
+	ERROR_FLAGS="-Werror-implicit-function-declaration -Wno-unused-variable -Wno-uninitialized -Werror=int-conversion -Werror=discarded-qualifiers"
+	HEADER_FILE="xpmem_kernel.h"
+}
+
+msg_checking() {
+	if [ "$silent" != 0 ]; then
+		return
+	fi
+	echo -n "Checking $*: "
+}
+
+msg_error() {
+	echo "Error: $*"
+	exit 1
+}
+
+msg_result() {
+	if [ "$silent" != 0 ]; then
+		return
+	fi
+	echo "$*"
+}
+
+msg_notice() {
+	if [ "$silent" != 0 ]; then
+		return
+	fi
+	echo "$*"
+}
+
+gen_test_case() {
+	local mod_name mod_dir
+
+	mod_name="$1"
+	mod_dir="$TEST_MODULES_DIR/$mod_name"
+	rm -rf "$mod_dir"
+	mkdir -p "$mod_dir"
+	cat <<EOF >"$mod_dir/$TEST_MOD_NAME.c"
+#include <linux/module.h>
+#include <linux/kernel.h>
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("test module for $mod_name");
+`cat "$TEST_CASES_DIR/$mod_name.init"`
+static int __init test_func (void) {
+`cat "$TEST_CASES_DIR/$mod_name.main"`
+	return 0;
+}
+module_init(test_func);
+EOF
+	echo "obj-m += $TEST_MOD_NAME.o" >"$mod_dir/Makefile"
+	echo "obj-\$(XPMEM_TEST)\$(XPMEM_TEST_$mod_name) += $mod_name/" >>"$TEST_MODULES_DIR/Makefile"
+}
+
+build_test_modules() {
+	msg_notice "Test-building kernel modules test-builds"
+	make -s -C "$KSRC" -k -j$NJOBS EXTRA_CFLAGS="$ERROR_FLAGS" "M=$TEST_MODULES_DIR" XPMEM_TEST=m modules >"$TEST_RUN_LOG" 2>&1
+	msg_notice ''
+}
+
+check_test_results() {
+	local mod_dir test_name rc
+
+	rm -f "$HEADER_FILE"
+	echo "#ifndef __XPMEM_KERNEL__" >>"$HEADER_FILE"
+	echo "#define __XPMEM_KERNEL__" >>"$HEADER_FILE"
+	msg_notice "Results of kernel tests:"
+	for mod_dir in "$TEST_MODULES_DIR"/HAVE_*; do
+		if test ! -d "$mod_dir"; then continue; fi
+		test_name="${mod_dir##*/}"
+		test ! -e "$mod_dir/$TEST_MOD_NAME.o"
+		rc=$?
+		desc_file="$TEST_CASES_DIR/$test_name.desc"
+		if [ -f "$desc_file" ]; then
+			echo "// $test_name: `cat "$desc_file"`" >> "$HEADER_FILE"
+		fi
+		if [ "$rc" != 0 ]; then
+			echo "#define $test_name $rc" >>"$HEADER_FILE"
+		else
+			echo "#undef $test_name" >>"$HEADER_FILE"
+		fi
+		msg_notice "- $test_name: $rc"
+	done
+}
+
+# First case: The configure script passes version string as the env var
+#             XPMEM_VERSION .
+# Second case: The configure script was already run successfully and set
+#              version string in dkms.conf. Get it from there. This works
+#              in both local and dkms builds.
+get_package_version() {
+	if [ -n "$XPMEM_VERSION" ]; then
+		echo "$XPMEM_VERSION"
+		return
+	fi
+	# Assumes that dkms.conf is .. (see cd in set_globals). May
+	# break out-fo-tree builds.
+	awk -F'"' '/^PACKAGE_VERSION/ {print $2}' ../dkms.conf
+}
+
+# FIXME: another place where we write to the config file:
+post_process() {
+	local version
+	if grep -q '^#define HAVE_PDE_DATA ' "$HEADER_FILE"; then
+		echo "#undef HAVE_NO_PDE_DATA_FUNC" >> "$HEADER_FILE"
+	else
+		echo "#define HAVE_NO_PDE_DATA_FUNC 1" >> "$HEADER_FILE"
+	fi
+	version=`get_package_version`
+	echo "#define PACKAGE_VERSION \"$version\"" >>"$HEADER_FILE"
+	echo "#endif" >>"$HEADER_FILE"
+}
+
+check_build_sanity() {
+	local rc
+	msg_checking "that system can build kernel modules"
+	gen_test_case KBUILD_WORKS "building a kernel module works"
+	make -s -C "$KSRC" EXTRA_CFLAGS="$ERROR_FLAGS" "M=$TEST_MODULES_DIR" XPMEM_TEST_KBUILD_WORKS=m modules 2>"$TEST_RUN_LOG"
+	rc=$?
+	if test "$rc" != 0; then
+		echo ''; cat "$TEST_RUN_LOG"
+		msg_error "Failed to build a dummy kernel module. Check compiler, kernel headers, etc."
+	fi
+	msg_result "yes"
+}
+
+get_tested_modules() {
+	printf '%s\n' "$TEST_CASES_DIR"/HAVE_*.init | sed 's|.*/||; s|\.init$||'
+}
+
+create_test_modules() {
+	local mod
+
+	rm -rf "${TEST_MODULES_DIR}"
+	mkdir -p "${TEST_MODULES_DIR}"
+
+	check_build_sanity
+
+	for mod in `get_tested_modules`; do
+		gen_test_case "$mod"
+	done
+}
+
+run_all() {
+	set_globals
+	create_test_modules
+	build_test_modules
+	check_test_results
+	post_process
+}
+
+# re-run a single test, after it was built
+run_test() {
+	set_globals
+	make -C "$KSRC" "M=$TEST_MODULES_DIR" "XPMEM_TEST_$1=m" modules EXTRA_CFLAGS="$ERROR_FLAGS"
+}
+
+
+silent=0
+while getopts hq opt; do
+	case "$opt" in
+	h) usage; exit 0;;
+	q) silent=1;;
+	\?) usage; exit 1;;
+	esac
+done
+shift $((OPTIND - 1))
+
+case "$1" in
+HAVE_* | TEST_KBUILD) run_test "$1";;
+'') run_all;;
+*) usage; exit 1;;
+esac

--- a/kernel/config_kernel
+++ b/kernel/config_kernel
@@ -13,6 +13,7 @@ Usage:
 
 Options:
 
+-o DIR - Output (and scratch) dir, for Out-of-tree build
 -q  Run quietly. Only print errors
 -h  Print this message
 
@@ -26,15 +27,19 @@ set_ksrc() {
 }
 
 set_globals() {
+	OUTPUT_DIR="$PWD"
+	if [ "$opt_output_dir" != '' ]; then
+		OUTPUT_DIR="$opt_output_dir"
+	fi
 	cd "`dirname "$0"`" || exit 2
 	set_ksrc
 	NJOBS=$(($(nproc)+1)) # FIXME: calibrate -j
-	TEST_MODULES_DIR="$PWD/test_mods"
+	TEST_MODULES_DIR="$OUTPUT_DIR/test_mods"
 	TEST_CASES_DIR="$PWD/test_cases"
 	TEST_MOD_NAME="testmod"
 	TEST_RUN_LOG="$TEST_MODULES_DIR/run.log"
-	ERROR_FLAGS="-Werror-implicit-function-declaration -Wno-unused-variable -Wno-uninitialized -Werror=int-conversion -Werror=discarded-qualifiers"
-	HEADER_FILE="xpmem_kernel.h"
+	ERROR_FLAGS="-Werror-implicit-function-declaration -Wno-unused-variable -Wno-uninitialized"
+	HEADER_FILE="$OUTPUT_DIR/xpmem_kernel.h"
 }
 
 msg_checking() {
@@ -109,7 +114,7 @@ check_test_results() {
 			echo "// $test_name: `cat "$desc_file"`" >> "$HEADER_FILE"
 		fi
 		if [ "$rc" != 0 ]; then
-			echo "#define $test_name $rc" >>"$HEADER_FILE"
+			echo "#define $test_name 1" >>"$HEADER_FILE"
 		else
 			echo "#undef $test_name" >>"$HEADER_FILE"
 		fi
@@ -186,14 +191,21 @@ run_all() {
 # re-run a single test, after it was built
 run_test() {
 	set_globals
-	make -C "$KSRC" "M=$TEST_MODULES_DIR" "XPMEM_TEST_$1=m" modules EXTRA_CFLAGS="$ERROR_FLAGS"
+	if [ ! -d "$TEST_MODULES_DIR" ]; then
+		msg_error "Specific tests can only be run after an initial run built test modules."
+	fi
+	rm -f "$TEST_MODULES_DIR/$1/$TEST_MOD_NAME.o"
+	make -C "$KSRC" EXTRA_CFLAGS="$ERROR_FLAGS" "M=$TEST_MODULES_DIR" "XPMEM_TEST_$1=m" modules
+
 }
 
 
 silent=0
-while getopts hq opt; do
+opt_output_dir=''
+while getopts ho:q opt; do
 	case "$opt" in
 	h) usage; exit 0;;
+	o) opt_output_dir=$OPTARG;;
 	q) silent=1;;
 	\?) usage; exit 1;;
 	esac
@@ -201,7 +213,8 @@ done
 shift $((OPTIND - 1))
 
 case "$1" in
-HAVE_* | TEST_KBUILD) run_test "$1";;
+HAVE_* | KBUILD_WORKS) run_test "$1";;
+sanity) run_test KBUILD_WORKS;;
 '') run_all;;
 *) usage; exit 1;;
 esac

--- a/kernel/test_cases/HAVE_DECL_VMA_ITER_INIT.init
+++ b/kernel/test_cases/HAVE_DECL_VMA_ITER_INIT.init
@@ -1,0 +1,1 @@
+#include <linux/mm_types.h>

--- a/kernel/test_cases/HAVE_DECL_VMA_ITER_INIT.main
+++ b/kernel/test_cases/HAVE_DECL_VMA_ITER_INIT.main
@@ -1,0 +1,1 @@
+(void) vma_iter_init;

--- a/kernel/test_cases/HAVE_DECL_VM_FLAGS_SET.init
+++ b/kernel/test_cases/HAVE_DECL_VM_FLAGS_SET.init
@@ -1,0 +1,1 @@
+#include <linux/mm.h>

--- a/kernel/test_cases/HAVE_DECL_VM_FLAGS_SET.main
+++ b/kernel/test_cases/HAVE_DECL_VM_FLAGS_SET.main
@@ -1,0 +1,1 @@
+(void) vm_flags_set;

--- a/kernel/test_cases/HAVE_GUP_4_10.init
+++ b/kernel/test_cases/HAVE_GUP_4_10.init
@@ -1,0 +1,1 @@
+#include <linux/mm.h>

--- a/kernel/test_cases/HAVE_GUP_4_10.main
+++ b/kernel/test_cases/HAVE_GUP_4_10.main
@@ -1,0 +1,4 @@
+long get_user_pages_remote(struct task_struct *tsk, struct mm_struct *mm,
+                            unsigned long start, unsigned long nr_pages,
+                            unsigned int gup_flags, struct page **pages,
+                            struct vm_area_struct **vmas, int *locked);

--- a/kernel/test_cases/HAVE_GUP_4_8.init
+++ b/kernel/test_cases/HAVE_GUP_4_8.init
@@ -1,0 +1,1 @@
+#include <linux/mm.h>

--- a/kernel/test_cases/HAVE_GUP_4_8.main
+++ b/kernel/test_cases/HAVE_GUP_4_8.main
@@ -1,0 +1,4 @@
+long get_user_pages_remote(struct task_struct *tsk, struct mm_struct *mm,
+                            unsigned long start, unsigned long nr_pages,
+                            int write, int force, struct page **pages,
+                            struct vm_area_struct **vmas);

--- a/kernel/test_cases/HAVE_GUP_4_9.init
+++ b/kernel/test_cases/HAVE_GUP_4_9.init
@@ -1,0 +1,1 @@
+#include <linux/mm.h>

--- a/kernel/test_cases/HAVE_GUP_4_9.main
+++ b/kernel/test_cases/HAVE_GUP_4_9.main
@@ -1,0 +1,4 @@
+long get_user_pages_remote(struct task_struct *tsk, struct mm_struct *mm,
+                            unsigned long start, unsigned long nr_pages,
+                            unsigned int gup_flags, struct page **pages,
+                            struct vm_area_struct **vmas);

--- a/kernel/test_cases/HAVE_GUP_5_9.init
+++ b/kernel/test_cases/HAVE_GUP_5_9.init
@@ -1,0 +1,1 @@
+#include <linux/mm.h>

--- a/kernel/test_cases/HAVE_GUP_5_9.main
+++ b/kernel/test_cases/HAVE_GUP_5_9.main
@@ -1,0 +1,4 @@
+long get_user_pages_remote(struct mm_struct *mm,
+                            unsigned long start, unsigned long nr_pages,
+                            unsigned int gup_flags, struct page **pages,
+                            struct vm_area_struct **vmas, int *locked);

--- a/kernel/test_cases/HAVE_GUP_6_5.init
+++ b/kernel/test_cases/HAVE_GUP_6_5.init
@@ -1,0 +1,1 @@
+#include <linux/mm.h>

--- a/kernel/test_cases/HAVE_GUP_6_5.main
+++ b/kernel/test_cases/HAVE_GUP_6_5.main
@@ -1,0 +1,4 @@
+long get_user_pages_remote(struct mm_struct *mm,
+                           unsigned long start, unsigned long nr_pages,
+                           unsigned int gup_flags, struct page **pages,
+                           int *locked);

--- a/kernel/test_cases/HAVE_LATEST_APPLY_TO_PAGE_RANGE.init
+++ b/kernel/test_cases/HAVE_LATEST_APPLY_TO_PAGE_RANGE.init
@@ -1,0 +1,2 @@
+#include <linux/mm.h>
+extern pte_fn_t callback;

--- a/kernel/test_cases/HAVE_LATEST_APPLY_TO_PAGE_RANGE.main
+++ b/kernel/test_cases/HAVE_LATEST_APPLY_TO_PAGE_RANGE.main
@@ -1,0 +1,1 @@
+int a = callback(NULL, 1, NULL);

--- a/kernel/test_cases/HAVE_PDE_DATA.desc
+++ b/kernel/test_cases/HAVE_PDE_DATA.desc
@@ -1,0 +1,1 @@
+Used to calculate HAVE_NO_PDE_DATA_FUNC at post-process

--- a/kernel/test_cases/HAVE_PDE_DATA.init
+++ b/kernel/test_cases/HAVE_PDE_DATA.init
@@ -1,0 +1,1 @@
+#include <linux/proc_fs.h>

--- a/kernel/test_cases/HAVE_PDE_DATA.main
+++ b/kernel/test_cases/HAVE_PDE_DATA.main
@@ -1,0 +1,1 @@
+pde_data(NULL);

--- a/kernel/test_cases/HAVE_PDE_DATA_MACRO.init
+++ b/kernel/test_cases/HAVE_PDE_DATA_MACRO.init
@@ -1,0 +1,1 @@
+#include <linux/proc_fs.h>

--- a/kernel/test_cases/HAVE_PDE_DATA_MACRO.main
+++ b/kernel/test_cases/HAVE_PDE_DATA_MACRO.main
@@ -1,0 +1,1 @@
+PDE_DATA(NULL);

--- a/kernel/test_cases/HAVE_PMD_LEAF_MACRO.init
+++ b/kernel/test_cases/HAVE_PMD_LEAF_MACRO.init
@@ -1,0 +1,1 @@
+#include <linux/mm.h>

--- a/kernel/test_cases/HAVE_PMD_LEAF_MACRO.main
+++ b/kernel/test_cases/HAVE_PMD_LEAF_MACRO.main
@@ -1,0 +1,4 @@
+#ifndef pmd_leaf
+#error "pmd_leaf macro not defined"
+#endif
+

--- a/kernel/test_cases/HAVE_PTE_OFFSET_MAP_MACRO.init
+++ b/kernel/test_cases/HAVE_PTE_OFFSET_MAP_MACRO.init
@@ -1,0 +1,1 @@
+#include <linux/mm.h>

--- a/kernel/test_cases/HAVE_PTE_OFFSET_MAP_MACRO.main
+++ b/kernel/test_cases/HAVE_PTE_OFFSET_MAP_MACRO.main
@@ -1,0 +1,4 @@
+#ifndef pte_offset_map
+#error "pte_offset_map macro not defined"
+#endif
+

--- a/kernel/test_cases/HAVE_PUD_LEAF_MACRO.init
+++ b/kernel/test_cases/HAVE_PUD_LEAF_MACRO.init
@@ -1,0 +1,1 @@
+#include <linux/mm.h>

--- a/kernel/test_cases/HAVE_PUD_LEAF_MACRO.main
+++ b/kernel/test_cases/HAVE_PUD_LEAF_MACRO.main
@@ -1,0 +1,4 @@
+#ifndef pud_leaf
+#error "pud_leaf macro not defined"
+#endif
+

--- a/kernel/test_cases/HAVE_STRUCT_TASK_STRUCT_CPUS_MASK.init
+++ b/kernel/test_cases/HAVE_STRUCT_TASK_STRUCT_CPUS_MASK.init
@@ -1,0 +1,1 @@
+#include <linux/sched.h>

--- a/kernel/test_cases/HAVE_STRUCT_TASK_STRUCT_CPUS_MASK.main
+++ b/kernel/test_cases/HAVE_STRUCT_TASK_STRUCT_CPUS_MASK.main
@@ -1,0 +1,3 @@
+/* Check  if struct task_struct has member cpu_mask */
+struct task_struct task_struct = {};
+return sizeof(task_struct.cpus_mask);

--- a/kernel/xpmem_misc.c
+++ b/kernel/xpmem_misc.c
@@ -16,7 +16,7 @@
 #include <linux/proc_fs.h>
 #include <linux/seq_file.h>
 #include <linux/uaccess.h>
-#include <xpmem.h>
+#include "xpmem.h"
 #include "xpmem_private.h"
 #include <linux/module.h>
 

--- a/kernel/xpmem_private.h
+++ b/kernel/xpmem_private.h
@@ -368,7 +368,7 @@ static inline struct xpmem_thread_group *__xpmem_tg_ref_by_tgid_nolock(pid_t tgi
 #define xpmem_mmap_read_trylock(_mm)	mmap_read_trylock(_mm)
 #endif
 
-#if (!HAVE_DECL_VMA_ITER_INIT)
+#ifndef HAVE_DECL_VMA_ITER_INIT
 struct vma_iterator {
 	struct mm_struct *mm;
 	unsigned long start;
@@ -384,7 +384,7 @@ struct vma_iterator {
 	     (_vma) = (_vma)->vm_next)
 #endif
 
-#if (!HAVE_DECL_VM_FLAGS_SET)
+#ifndef HAVE_DECL_VM_FLAGS_SET
 static inline void vm_flags_set(struct vm_area_struct *vma, vm_flags_t flags)
 {
 	vma->vm_flags |= flags;

--- a/m4/ac_kernel_checks.m4
+++ b/m4/ac_kernel_checks.m4
@@ -95,129 +95,17 @@ AC_DEFUN([AC_KERNEL_CHECKS],
 ]
 )
 
-AC_DEFUN([AC_GUP_CHECK], [
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <linux/mm.h>]], [[
-	$1
-  ]])], [
-    AS_IF([test x"$gup_version" != xno], [AC_MSG_ERROR([get_user_pages_remote has multiple matches])])
-    gup_version=$2
-    AC_DEFINE([$3], 1, [Have get_user_pages_remote() kernel >= $gup_version])
-  ])
-])
-
-AC_DEFUN([AC_KERNEL_CHECK_GUP],
-[
-  AC_MSG_CHECKING(get_user_pages_remote version)
-  gup_version=no
-  AC_GUP_CHECK([
-	long get_user_pages_remote(struct mm_struct *mm,
-				   unsigned long start, unsigned long nr_pages,
-				   unsigned int gup_flags, struct page **pages,
-				   int *locked);],
-	[6.5], [HAVE_GUP_6_5])
-  AC_GUP_CHECK([
-	long get_user_pages_remote(struct mm_struct *mm,
-				    unsigned long start, unsigned long nr_pages,
-				    unsigned int gup_flags, struct page **pages,
-				    struct vm_area_struct **vmas, int *locked);],
-	[5.9], [HAVE_GUP_5_9])
-  AC_GUP_CHECK([
-	long get_user_pages_remote(struct task_struct *tsk, struct mm_struct *mm,
-				    unsigned long start, unsigned long nr_pages,
-				    unsigned int gup_flags, struct page **pages,
-				    struct vm_area_struct **vmas, int *locked);],
-	[4.10], [HAVE_GUP_4_10])
-  AC_GUP_CHECK([
-	long get_user_pages_remote(struct task_struct *tsk, struct mm_struct *mm,
-				    unsigned long start, unsigned long nr_pages,
-				    unsigned int gup_flags, struct page **pages,
-				    struct vm_area_struct **vmas);],
-	[4.9], [HAVE_GUP_4_9])
-  AC_GUP_CHECK([
-	long get_user_pages_remote(struct task_struct *tsk, struct mm_struct *mm,
-				    unsigned long start, unsigned long nr_pages,
-				    int write, int force, struct page **pages,
-				    struct vm_area_struct **vmas);],
-	[4.8], [HAVE_GUP_4_8])
-
-  AS_IF([test "$gup_version" = no && test "${kernelvers%%.*}" -ge 5],
-        [AC_MSG_ERROR([could not find get_user_pages_remote function for kernel >=5.x.x])])
-
-  AC_MSG_RESULT(${gup_version//_/.})
-]
-)
-
 AC_DEFUN([AC_KERNEL_CHECK_SUPPORT],
 [
-  srcarch=$(uname -m | sed -e s/i.86/x86/ \
-                           -e s/x86_64/x86/ \
-                           -e s/ppc.*/powerpc/ \
-                           -e s/powerpc64/powerpc/ \
-                           -e s/aarch64.*/arm64/ \
-                           -e s/sparc32.*/sparc/ \
-                           -e s/sparc64.*/sparc/ \
-                           -e s/s390x/s390/)
-  save_CFLAGS="$CFLAGS"
-  save_CPPFLAGS="$CPPFLAGS"
-  CFLAGS="${KERNEL_CHECKS_CFLAGS:--g -O2}"
-  CPPFLAGS="-include $kernelinc/include/linux/kconfig.h \
-            -include $kernelinc/include/linux/compiler.h \
-            -D__KERNEL__ \
-            -DKBUILD_MODNAME=\"xpmem_configure\" \
-            -I$kernelinc/include \
-            -I$kernelinc/include/uapi \
-            -I$kernelinc/arch/$srcarch/include \
-            -I$kernelinc/arch/$srcarch/include/uapi \
-            -I$kernelinc/arch/$srcarch/include/generated \
-            -I$kernelinc/arch/$srcarch/include/generated/uapi \
-            $CPPFLAGS"
-
-  AC_CHECK_DECL([kmalloc], [], [
-    AC_MSG_ERROR([cannot run kernel module configuration checks])], [[
-    #include <linux/slab.h>
-    #include <linux/mm.h>
-    #include <linux/sched.h>
-    #include <linux/mm_types.h>
-    #include <linux/proc_fs.h>]])
-
-  AC_CHECK_MEMBERS([struct task_struct.cpus_mask], [], [],
-                   [[#include <linux/sched.h>]])
-
-  AC_CHECK_DECL(pde_data, [], [
-    AC_DEFINE([HAVE_NO_PDE_DATA_FUNC], 1, [Have pde_data()])
-    AC_CHECK_DECL(PDE_DATA, [
-      AC_DEFINE([HAVE_PDE_DATA_MACRO], 1, [Have PDE_DATA()])
-    ], [], [[#include <linux/proc_fs.h>]])
-  ], [[#include <linux/proc_fs.h>]])
-
-  AC_CHECK_DECL(pmd_leaf, [
-    AC_DEFINE([HAVE_PMD_LEAF_MACRO], 1, [Have pmd_leaf()])],
-    [], [[#include <linux/mm.h>]])
-  AC_CHECK_DECL(pud_leaf, [
-    AC_DEFINE([HAVE_PUD_LEAF_MACRO], 1, [Have pud_leaf()])],
-    [], [[#include <linux/mm.h>]])
-  AC_CHECK_DECL(pte_offset_map, [
-    AC_DEFINE([HAVE_PTE_OFFSET_MAP_MACRO], 1, [Have pte_offset_map()])],
-    [], [[#include <linux/mm.h>]])
-
-  AC_CHECK_DECLS([vma_iter_init], [], [], [[#include <linux/mm_types.h>]])
-
-  AC_MSG_CHECKING(latest apply_to_page_range support)
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-      #include <linux/mm.h>
-      extern pte_fn_t callback;
-    ]], [[
-      int a = callback(NULL, 1, NULL);
-    ]])], [
-    AC_DEFINE([HAVE_LATEST_APPLY_TO_PAGE_RANGE], 1, [Have latest page iterator])
-    AC_MSG_RESULT(yes)
-  ], [AC_MSG_RESULT(no)])
-
-  AC_CHECK_DECLS([vm_flags_set], [], [], [[#include <linux/mm.h>]])
-  AC_KERNEL_CHECK_GUP
-
-  AC_SUBST(KFLAGS, [$KFLAGS])
-  CPPFLAGS="$save_CPPFLAGS"
-  CFLAGS="$save_CFLAGS"
-]
-)
+  __xpmem_silent_opt=''
+  # Will print its own messages:
+  if test "$silent" = "yes"; then
+    __xpmem_silent_opt="-q"
+  fi
+  # FIXME: what about out-of-tree build?
+  env KSRC=$kerneldir XPMEM_VERSION="$PACKAGE_VERSION" kernel/config_kernel $__xpmem_silent_opt
+  if test $? -ne 0; then
+    AC_MSG_ERROR([Failed to configure kernel. Missing kernel headers (-devel) or broken build system])
+  fi
+  unset __xpmem_silent_opt
+])

--- a/m4/ac_kernel_checks.m4
+++ b/m4/ac_kernel_checks.m4
@@ -102,8 +102,8 @@ AC_DEFUN([AC_KERNEL_CHECK_SUPPORT],
   if test "$silent" = "yes"; then
     __xpmem_silent_opt="-q"
   fi
-  # FIXME: what about out-of-tree build?
-  env KSRC=$kerneldir XPMEM_VERSION="$PACKAGE_VERSION" kernel/config_kernel $__xpmem_silent_opt
+  env KSRC="$kerneldir" XPMEM_VERSION="$PACKAGE_VERSION" \
+    ${srcdir}/kernel/config_kernel -o `realpath kernel` $__xpmem_silent_opt
   if test $? -ne 0; then
     AC_MSG_ERROR([Failed to configure kernel. Missing kernel headers (-devel) or broken build system])
   fi

--- a/m4/ac_kernel_checks.m4
+++ b/m4/ac_kernel_checks.m4
@@ -103,7 +103,7 @@ AC_DEFUN([AC_KERNEL_CHECK_SUPPORT],
     __xpmem_silent_opt="-q"
   fi
   env KSRC="$kerneldir" XPMEM_VERSION="$PACKAGE_VERSION" \
-    ${srcdir}/kernel/config_kernel -o `realpath kernel` $__xpmem_silent_opt
+    sh ${srcdir}/kernel/config_kernel -o `realpath kernel` $__xpmem_silent_opt
   if test $? -ne 0; then
     AC_MSG_ERROR([Failed to configure kernel. Missing kernel headers (-devel) or broken build system])
   fi


### PR DESCRIPTION
Kernel is configured by querying the kernel build system directly, and
kernel directory can be built independetly of autoconf.

This solves several separate issues:
* Having to carry all of autoconf to the DKMS directory
* The compiler that autoconf detects by default may not be the one
  that the kernel needs.
  - It is even OK to not have "gcc" and have "gcc-14" if that is what
    the kernel needs, but autoconf will still be picky.
* Various other issues are best detected by the kernel build system
  directly, and not trying ot second-guess it, as this occasionally
  changes.
  - One exception: clang support requires explicitly setting
    LLVM=1 . Not done automatically for now.

Changes:
* m4/ac_kernel_checks.m4 has mostly been replaced by the script
  kernel/config_kernel
  - This script can also be run manually. See dkms.conf .
  - The script does not include tests. They are in files under
    kernel/test_cases/
  - kernel/ can be run without autoconf: kernel/Kbuild was simplified.
  - And alternative Makefile for it is provided as kernel/Makefile.dkms
* Using relative path to generated include file rather than path
  in a generated file from autoconf

The test works by creating a kernel module for each test and
building all of them with the kernel build system and with the -k
option of make and check which of them built successfully.

As an initial stage, we run a test build of a single empty module
just to be sure that the build system works.

To simplify debugging, kernel tests can be re-run separately (after
main script was run) using e.g.:

  kernel/config_kernel HAVE_PUD_LEAF_MACRO