### PR TITLE
Move udev rules to /lib

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,8 +10,8 @@ endif
 
 pkgconfig_DATA = cray-xpmem.pc
 
-sysconf_DATA = .version \
-	       56-xpmem.rules
+udevrules_DATA = 56-xpmem.rules
+udevrulesdir = /lib/udev/rules.d
 
 EXTRA_DIST = \
 	56-xpmem.rules \

--- a/xpmem-kmod.spec.in
+++ b/xpmem-kmod.spec.in
@@ -40,13 +40,12 @@ make
 export INSTALL_MOD_PATH=$RPM_BUILD_ROOT
 export INSTALL_MOD_DIR=extra/%{module}
 make -C kernel modules_install
-mkdir -p $RPM_BUILD_ROOT/etc/udev/rules.d
-cp 56-xpmem.rules $RPM_BUILD_ROOT/etc/udev/rules.d
+mkdir -p $RPM_BUILD_ROOT/lib/udev/rules.d
+cp 56-xpmem.rules $RPM_BUILD_ROOT/lib/udev/rules.d
 find $RPM_BUILD_ROOT -name 'xpmem.*' | sed -e s@^$RPM_BUILD_ROOT@@ >filelist
 
 %files -f filelist
-/etc/udev/rules.d/56-xpmem.rules
+/lib/udev/rules.d/56-xpmem.rules
 
 %post
-touch /etc/udev/rules.d/56-xpmem.rules
 depmod -a


### PR DESCRIPTION
Udev rules in packages should be under /lib/udev (or rather: /usr/lib/udev for most later distributions, but that's for later) and have been there for at least 10 years now. Files under /etc are for overrides of the system administrator.