### PR TITLE
Add option -fms-extensions to kernel tests

### DIFF
--- a/m4/ac_kernel_checks.m4
+++ b/m4/ac_kernel_checks.m4
@@ -159,7 +159,7 @@ AC_DEFUN([AC_KERNEL_CHECK_SUPPORT],
                            -e s/s390x/s390/)
   save_CFLAGS="$CFLAGS"
   save_CPPFLAGS="$CPPFLAGS"
-  CFLAGS="${KERNEL_CHECKS_CFLAGS:--g -O2}"
+  CFLAGS="${KERNEL_CHECKS_CFLAGS:--g -O2 -fms-extensions}"
   CPPFLAGS="-include $kernelinc/include/linux/kconfig.h \
             -include $kernelinc/include/linux/compiler.h \
             -D__KERNEL__ \


### PR DESCRIPTION
Kernel versions >= 6.19 are being built with -fms-extensions, and this allows simpler handling of annonymous structs. 

Without it, a simple test of code that includes '#include <linux/fs.h>' fails in Linux 7.0.